### PR TITLE
Accept generator in writerow

### DIFF
--- a/odswriter/__init__.py
+++ b/odswriter/__init__.py
@@ -105,13 +105,7 @@ class Sheet(object):
 
     def writerow(self, cells):
         row = self.dom.createElement("table:table-row")
-        content_cells = len(cells)
-
-        if self.cols is not None:
-            padding_cells = self.cols - content_cells
-            if content_cells > self.cols:
-                raise Exception("More cells than cols.")
-            cells += [None]*padding_cells
+        content_cells = 0
 
         for cell_data in cells:
             cell = self.dom.createElement("table:table-cell")
@@ -164,6 +158,16 @@ class Sheet(object):
                 cell.appendChild(p)
 
             row.appendChild(cell)
+
+            content_cells += 1
+
+        if self.cols is not None:
+            if content_cells > self.cols:
+                raise Exception("More cells than cols.")
+
+            for _ in range(content_cells, self.cols):
+                cell = self.dom.createElement("table:table-cell")
+                row.appendChild(cell)
 
         self.table.appendChild(row)
 


### PR DESCRIPTION
A generator has not `__len__` attribute, disallowing supplying one in
`Sheet.writerow()`.

This PR makes the for-loop count the number of cells, so the method does
not need to know the number of cells in advance.

-----

Sorry, I'll supply tests later. I just want to make sure that I don't forget to report anything.

Thank you very much for your library. It works great and the code is well written!